### PR TITLE
Updated README.md with current kali image config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ sudo dd if=/home/PROFILE NAME/kali-linux-2019.2a-rpi3-nexmon-64.img of=/dev/mmcb
 Insert the SD Card into the Pi and ssh to the new system with the following details:
 
 ```
-username: root
-password: toor
+username: kali
+password: kali
 ```
 
 Please ensure you regenerate the SSH keys and update the password, otherwise you will be hacked.
 
 ```
 cd /etc/ssh/
-mkdir default_kali_keys
-mv ssh_host_* default_kali_keys/
+sudo mkdir default_kali_keys
+sudo mv ssh_host_* default_kali_keys/
 
-dpkg-reconfigure openssh-server
-passwd
+sudo dpkg-reconfigure openssh-server
+sudo passwd kali
 exit
 
 ```


### PR DESCRIPTION
The Readme was oudated because kali has changed some default structures and profiles.
I ran through all commands and updated those that weren't compatible anymore.
e.g. root is disabled by default

- default user and pass are:
    kali:kali
- added 'sudo' to commands where necessary

kudos to this project in general